### PR TITLE
Removing exceed bendpoints in a simple way

### DIFF
--- a/org.example.manhattanConnectionRouter/src/org/example/feature/BaseManhattanConnectionRouter.java
+++ b/org.example.manhattanConnectionRouter/src/org/example/feature/BaseManhattanConnectionRouter.java
@@ -193,33 +193,29 @@ public class BaseManhattanConnectionRouter extends BendpointConnectionRouter {
 
 	public List<Point> calculateSegments(List<Coordinate> points) {
 		List<Point> result = new ArrayList<Point>();
-			
-			for (int i = points.size() - 1; i >= 0; i--) {
-				
-//				if(((i > 0) && (i<points.size()))  && (points.get(i).y == points.get(i-1).y) && (points.get(i).y == points.get(i+1).y)){
-//					points.remove(points.get(i));
-//					continue;
-//				}
-//				if(((i > 0) && (i<points.size()))  && (points.get(i).x == points.get(i-1).x) && (points.get(i).x == points.get(i+1).x)){
-//					points.remove(points.get(i));
-//					continue;
-//				}
-				Point p=GraphicsUtil.createPoint(points.get(i).x, points.get(i).y);
-				
-				result.add(GraphicsUtil.createPoint(points.get(i).x, points.get(i).y));
+		for (int i = points.size() - 1; i >= 0; i--) {
+			Coordinate curr = points.get(i);
+			if(i < 1 ){
+				result.add(GraphicsUtil.createPoint(curr.x, curr.y));
+				continue;
 			}
 			
-			/*Iterator<Coordinate> iter = points.iterator();
-			Coordinate prev = iter.next();
-			while(iter.hasNext()) {
-				Coordinate curr = iter.next();
-				Coordinate next = iter.next();
-				if(prev.x==curr.x&&curr.x!=next.x) result.add(GraphicsUtil.createPoint(curr.x, curr.y));
-				if(prev.y==curr.y&&curr.y!=next.y) result.add(GraphicsUtil.createPoint(curr.x, curr.y));
-				prev = iter.next();
-			}*/
+			if( i > points.size() - 2){
+				result.add(GraphicsUtil.createPoint(curr.x, curr.y));
+				continue;
+			}
+			
+			Coordinate prev = points.get(i+1);
+			Coordinate next = points.get(i-1);
+			if(prev.x==curr.x&&curr.x!=next.x) {
+				result.add(GraphicsUtil.createPoint(curr.x, curr.y));
+			}
+			if(prev.y==curr.y&&curr.y!=next.y){
+				result.add(GraphicsUtil.createPoint(curr.x, curr.y));
+			}
+		}
 		
-
+			
 		return result;
 	}
 	

--- a/org.example.manhattanConnectionRouter/src/org/example/feature/BaseManhattanConnectionRouter.java
+++ b/org.example.manhattanConnectionRouter/src/org/example/feature/BaseManhattanConnectionRouter.java
@@ -12,7 +12,6 @@
  ******************************************************************************/
 package org.example.feature;
 
-import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -39,7 +38,6 @@ import org.eclipse.graphiti.mm.pictograms.ContainerShape;
 import org.eclipse.graphiti.mm.pictograms.FixPointAnchor;
 import org.eclipse.graphiti.mm.pictograms.Shape;
 import org.eclipse.graphiti.services.Graphiti;
-import org.example.feature.BaseManhattanConnectionRouter.Coordinate;
 
 
 /**
@@ -120,7 +118,7 @@ public class BaseManhattanConnectionRouter extends BendpointConnectionRouter {
 		List<Point> reducedAstar = calculateSegments(astarResult);
 		route.getPoints().addAll(reducedAstar);
 		allRoutes.add(route);
-		System.out.println(route.isValid());
+		
 		drawConnectionRoutes(allRoutes);
 
 		return route;
@@ -149,8 +147,9 @@ public class BaseManhattanConnectionRouter extends BendpointConnectionRouter {
 
 		for (int i=0; i<allShapes.size(); ++i) {
 			ContainerShape s = allShapes.get(i);
-			if (shape==s)
+			if (shape==s){
 				continue;
+			}
 			DetourPoints d = new DetourPoints(s, offset);
 			if (detour.intersects(d) && !detour.contains(d)) {
 				detour.merge(d);
@@ -182,20 +181,31 @@ public class BaseManhattanConnectionRouter extends BendpointConnectionRouter {
 			Anchor anchor = iterator.next();
 			String property = Graphiti.getPeService().getPropertyValue(anchor, AnchorUtil.BOUNDARY_FIXPOINT_ANCHOR);
 			if (property != null && anchor instanceof FixPointAnchor) {
-				BoundaryAnchor a = new BoundaryAnchor();
-				a.anchor = (FixPointAnchor) anchor;
-				a.locationType = AnchorLocation.getLocation(property);
-				a.location = peService.getLocationRelativeToDiagram(anchor);
-				anchorList.add(a);
+				BoundaryAnchor boundaryAnchor = new BoundaryAnchor();
+				boundaryAnchor.anchor = (FixPointAnchor) anchor;
+				boundaryAnchor.locationType = AnchorLocation.getLocation(property);
+				boundaryAnchor.location = peService.getLocationRelativeToDiagram(anchor);
+				anchorList.add(boundaryAnchor);
 			}
 		}
 		return anchorList;
 	}
 
-	protected List<Point> calculateSegments(List<Coordinate> points) {
+	public List<Point> calculateSegments(List<Coordinate> points) {
 		List<Point> result = new ArrayList<Point>();
-
+			
 			for (int i = points.size() - 1; i >= 0; i--) {
+				
+//				if(((i > 0) && (i<points.size()))  && (points.get(i).y == points.get(i-1).y) && (points.get(i).y == points.get(i+1).y)){
+//					points.remove(points.get(i));
+//					continue;
+//				}
+//				if(((i > 0) && (i<points.size()))  && (points.get(i).x == points.get(i-1).x) && (points.get(i).x == points.get(i+1).x)){
+//					points.remove(points.get(i));
+//					continue;
+//				}
+				Point p=GraphicsUtil.createPoint(points.get(i).x, points.get(i).y);
+				
 				result.add(GraphicsUtil.createPoint(points.get(i).x, points.get(i).y));
 			}
 			
@@ -288,8 +298,8 @@ public class BaseManhattanConnectionRouter extends BendpointConnectionRouter {
 					closedset.add(neighbor);
 					continue;
 				}
-
-				int tentative_g_score = Integer.valueOf( getGScore(current)) + heuristicCostEstimate(current,neighbor); //the distance between current and neighbor is always 1
+				int gScoreValue= Integer.valueOf(getGScore(current));
+				int tentative_g_score = gScoreValue + heuristicCostEstimate(current,neighbor); //the distance between current and neighbor is always 1
 
 				if(!openset.contains(neighbor) || tentative_g_score < getGScore(current)) {
 					came_from.put(neighbor, current);

--- a/org.example.manhattanConnectionRouter/src/org/example/feature/BaseManhattanConnectionRouter.java
+++ b/org.example.manhattanConnectionRouter/src/org/example/feature/BaseManhattanConnectionRouter.java
@@ -74,6 +74,8 @@ public class BaseManhattanConnectionRouter extends BendpointConnectionRouter {
 	}
 
 	private AnchorVerifier anchorVerifier;
+	private Map<Coordinate, Integer> g_score;
+	private Map<Coordinate, Integer> f_score;
 
 	@Override
 	protected ConnectionRoute calculateRoute() {
@@ -219,9 +221,7 @@ public class BaseManhattanConnectionRouter extends BendpointConnectionRouter {
 			this.x = x;
 			this.y = y;
 		}
-		
-		
-		
+
 		@Override
 		public String toString() {
 			return "Coordinate [x=" + x + ", y=" + y + "]";
@@ -263,18 +263,17 @@ public class BaseManhattanConnectionRouter extends BendpointConnectionRouter {
 		openset.add(start);
 		Map<Coordinate, Coordinate> came_from = new HashMap<Coordinate, Coordinate>();
 
-		Map<Coordinate, Integer> g_score = new HashMap<Coordinate, Integer>();
+		g_score = new HashMap<Coordinate, Integer>();
 		g_score.put(start, 0);
 
-		Map<Coordinate, Integer> f_score = new HashMap<Coordinate, Integer>();
-		f_score.put(start, g_score.getOrDefault(start, Integer.MAX_VALUE)+heuristicCostEstimate(start, goal));
+		f_score = new HashMap<Coordinate, Integer>();
+		Integer currentGScore = getGScore(start);
+		f_score.put(start,currentGScore+heuristicCostEstimate(start, goal));
 
 		while(!openset.isEmpty()) {
 			Coordinate current = lowestFScore(f_score, openset);
-			System.out.println(current);
 			if(current.equals(goal)) {
 				return reconstructPath(came_from, goal);
-			
 			}
 
 
@@ -290,9 +289,9 @@ public class BaseManhattanConnectionRouter extends BendpointConnectionRouter {
 					continue;
 				}
 
-				int tentative_g_score = Integer.valueOf(g_score.get(current)) + heuristicCostEstimate(current,neighbor); //the distance between current and neighbor is always 1
+				int tentative_g_score = Integer.valueOf( getGScore(current)) + heuristicCostEstimate(current,neighbor); //the distance between current and neighbor is always 1
 
-				if(!openset.contains(neighbor) || tentative_g_score < g_score.getOrDefault(current, Integer.MAX_VALUE)) {
+				if(!openset.contains(neighbor) || tentative_g_score < getGScore(current)) {
 					came_from.put(neighbor, current);
 					g_score.put(neighbor, tentative_g_score);
 					f_score.put(neighbor, tentative_g_score + heuristicCostEstimate(neighbor, goal));
@@ -305,6 +304,15 @@ public class BaseManhattanConnectionRouter extends BendpointConnectionRouter {
 		alterResult.add(start);
 		alterResult.add(goal);
 		return alterResult;
+	}
+
+
+	private Integer getGScore(Coordinate start) {
+		Integer currentGScore = g_score.get(start);
+		if(currentGScore == null) {
+			currentGScore = Integer.MAX_VALUE;
+		}
+		return currentGScore;
 	}
 
 	public int heuristicCostEstimate(Coordinate a, Coordinate b) {

--- a/org.example.manhattanConnectionRouter/src/org/example/feature/BaseManhattanConnectionRouter.java
+++ b/org.example.manhattanConnectionRouter/src/org/example/feature/BaseManhattanConnectionRouter.java
@@ -331,13 +331,23 @@ public class BaseManhattanConnectionRouter extends BendpointConnectionRouter {
 
 	protected List<Coordinate> neighborNodes(Coordinate current, Coordinate goal) {
 		List<Coordinate> list = new ArrayList<Coordinate>();
-		int heuristicCostEstimate  = heuristicCostEstimate(current, goal);
+		int heuristicCostEstimate  = remainingDistance(current, goal);
 		int step = heuristicCostEstimate > A_STEP ? A_STEP: heuristicCostEstimate ;
 		list.add(new Coordinate(current.x+step, current.y));
 		list.add(new Coordinate(Math.abs(current.x-step), current.y));
 		list.add(new Coordinate(current.x, current.y+step));
 		list.add(new Coordinate(current.x, Math.abs(current.y-step)));
 		return list;
+	}
+	
+	private int remainingDistance(Coordinate a, Coordinate b){
+		if(a.x == b.x && a.y == b.y){
+			return 0;
+		} else if (a.x == b.x){
+			return Math.abs(a.y - b.y);
+		} else {
+			return Math.abs(a.x - b.x);
+		}
 	}
 
 	protected List<Coordinate> reconstructPath(Map<Coordinate, Coordinate> came_from, Coordinate current) {


### PR DESCRIPTION
This prevents the unnecessary addition of bendpoints when connecting two nodes.
